### PR TITLE
Chewbbaca batch input

### DIFF
--- a/modules/bwa/main.nf
+++ b/modules/bwa/main.nf
@@ -23,7 +23,7 @@ process bwa_index {
 
   script:
     """
-    bwa index ${reference}
+    bwa index ${reference} ${reference.baseName}/${reference}
     """
 }
 

--- a/modules/chewbbaca/main.nf
+++ b/modules/chewbbaca/main.nf
@@ -32,18 +32,15 @@ process chewbbaca_allelecall {
   script:
     missingLoci = "chewbbaca.missingloci"
     trainingFile = trainingFile ? "--ptf ${trainingFile}" : "" 
-    flockfile = file(params.localTempDir + '/chewbbaca.lock') 
-    flocking = flockfile.exists() ? "flock -e $flockfile \\" : ""
 
     """
-    ${flocking}
-      chewie AlleleCall \\
-      -i ${batchInput} \\
-      ${params.args.join(' ')} \\
-      --cpu ${task.cpus} \\
-      --output-directory output_dir \\
-      ${trainingFile} \\
-      --schema-directory ${schemaDir}
+    chewie AlleleCall \\
+    -i ${batchInput} \\
+    ${params.args.join(' ')} \\
+    --cpu ${task.cpus} \\
+    --output-directory output_dir \\
+    ${trainingFile} \\
+    --schema-directory ${schemaDir}
     #bash parse_missing_loci.sh batch_input.list 'output_dir/*/results_alleles.tsv' ${missingLoci}
     """
 }
@@ -62,7 +59,6 @@ process chewbbaca_create_batch_list {
 
   script:
     output = "batch_input.list"
-    //for i in $maskedAssembly ; do echo -e "\$PWD/\$i" >> $output ; done
     """
     realpath $maskedAssembly > $output
     """
@@ -83,7 +79,6 @@ process chewbbaca_split_results {
     tuple val(sampleName), path("${output}")
 
   script:
-    id = "${input.simpleName}"
     output = "${sampleName}.chewbbaca"
     """
     head -1 ${input} > ${output}

--- a/modules/cmd/main.nf
+++ b/modules/cmd/main.nf
@@ -156,8 +156,6 @@ process save_analysis_metadata {
     mode: params.publishDirMode, 
     overwrite: params.publishDirOverwrite
 
-  input:
-
   output:
     path(output)
 


### PR DESCRIPTION
The following changes were made:
* bwa output filepath was changed to avoid error listed in this https://github.com/nf-core/chipseq/issues/65.
* chewbbaca batch input list generator was created to avoid multiple processes competing for the same databases whilst running in parallel (https://github.com/B-UMMI/chewBBACA/issues/11).
* Modules involved in chewbbaca were updated to separate the resulting chewbbaca batch output.